### PR TITLE
feat: add admin role management

### DIFF
--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, ArrayNotEmpty, ArrayUnique, IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateRoleDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsInt({ each: true })
+  permissionIds: number[];
+}

--- a/backend/src/roles/dto/update-role.dto.ts
+++ b/backend/src/roles/dto/update-role.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateRoleDto } from './create-role.dto';
+
+export class UpdateRoleDto extends PartialType(CreateRoleDto) {}

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, ParseIntPipe } from '@nestjs/common';
 import { RolesService } from './roles.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
 @ApiTags('roles')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -13,4 +15,25 @@ export class RolesController {
   @Get()
   @Roles('ADMIN')
   findAll() { return this.rolesService.findAll(); }
+
+  @Post()
+  @Roles('ADMIN')
+  create(@Body() createRoleDto: CreateRoleDto) {
+    return this.rolesService.create(createRoleDto);
+  }
+
+  @Patch(':id')
+  @Roles('ADMIN')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateRoleDto: UpdateRoleDto,
+  ) {
+    return this.rolesService.update(id, updateRoleDto);
+  }
+
+  @Delete(':id')
+  @Roles('ADMIN')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.rolesService.remove(id);
+  }
 }

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -1,7 +1,48 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+
 @Injectable()
 export class RolesService {
   constructor(private prisma: PrismaService) {}
-  findAll() { return this.prisma.role.findMany({ include: { permissions: true } }); }
+
+  findAll() {
+    return this.prisma.role.findMany({ include: { permissions: true } });
+  }
+
+  create(createRoleDto: CreateRoleDto) {
+    return this.prisma.role.create({
+      data: {
+        name: createRoleDto.name,
+        permissions: {
+          connect: createRoleDto.permissionIds.map((id) => ({ id })),
+        },
+      },
+      include: { permissions: true },
+    });
+  }
+
+  update(id: number, updateRoleDto: UpdateRoleDto) {
+    return this.prisma.role.update({
+      where: { id },
+      data: {
+        name: updateRoleDto.name,
+        permissions: updateRoleDto.permissionIds
+          ? {
+              set: updateRoleDto.permissionIds.map((pid) => ({ id: pid })),
+            }
+          : undefined,
+      },
+      include: { permissions: true },
+    });
+  }
+
+  async remove(id: number) {
+    const usersWithRole = await this.prisma.user.count({ where: { roleId: id } });
+    if (usersWithRole > 0) {
+      throw new BadRequestException('Cannot delete a role that is assigned to users.');
+    }
+    return this.prisma.role.delete({ where: { id } });
+  }
 }

--- a/frontend/app/admin/permissions/page.tsx
+++ b/frontend/app/admin/permissions/page.tsx
@@ -145,6 +145,7 @@ export default function AdminPermissionsPage() {
 
       <nav className="mb-4 space-x-4">
         <Link href="/admin/users" className="text-blue-600 hover:underline">Users</Link>
+        <Link href="/admin/roles" className="text-blue-600 hover:underline">Roles</Link>
         <Link href="/admin/permissions" className="text-blue-600 hover:underline">Permissions</Link>
       </nav>
 

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import Link from 'next/link';
+import api from '@/lib/api';
+import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { PlusCircle, Trash2, Edit, X, AlertTriangle } from 'lucide-react';
+
+interface Permission {
+  id: number;
+  action: string;
+  subject: string;
+}
+
+interface Role {
+  id: number;
+  name: string;
+  permissions: Permission[];
+}
+
+type RoleFormInputs = { name: string; permissionIds: number[] };
+
+const RoleModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  permissions,
+  defaultValues,
+  title,
+  submitLabel,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: RoleFormInputs) => Promise<void>;
+  permissions: Permission[];
+  defaultValues?: RoleFormInputs;
+  title: string;
+  submitLabel: string;
+}) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<RoleFormInputs>({ defaultValues });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
+
+  if (!isOpen) return null;
+
+  const handleFormSubmit: SubmitHandler<RoleFormInputs> = async (data) => {
+    await onSubmit({
+      name: data.name,
+      permissionIds: data.permissionIds.map(Number),
+    });
+    reset();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white p-8 rounded-lg shadow-xl w-full max-w-md">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-2xl font-bold">{title}</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-800"><X size={24} /></button>
+        </div>
+        <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Name</label>
+            <input
+              {...register('name', { required: 'Name is required' })}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+            {errors.name && <p className="text-sm text-red-600 mt-1">{errors.name.message}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Permissions</label>
+            <div className="max-h-48 overflow-y-auto border p-2 rounded-md">
+              {permissions.map((p) => (
+                <label key={p.id} className="flex items-center space-x-2 mb-1">
+                  <input
+                    type="checkbox"
+                    value={p.id}
+                    {...register('permissionIds', { required: 'Select at least one permission' })}
+                  />
+                  <span>{p.action} {p.subject}</span>
+                </label>
+              ))}
+            </div>
+            {errors.permissionIds && <p className="text-sm text-red-600 mt-1">{errors.permissionIds.message as string}</p>}
+          </div>
+          <div className="flex justify-end pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="bg-gray-200 text-gray-800 px-4 py-2 rounded-md mr-2 hover:bg-gray-300"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-blue-400"
+            >
+              {isSubmitting ? 'Saving...' : submitLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+const DeleteRoleModal = ({
+  role,
+  isOpen,
+  onClose,
+  onConfirm,
+}: {
+  role: Role | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) => {
+  if (!isOpen || !role) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white p-8 rounded-lg shadow-xl w-full max-w-md">
+        <div className="flex items-start">
+          <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+            <AlertTriangle className="h-6 w-6 text-red-600" />
+          </div>
+          <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 className="text-lg leading-6 font-medium text-gray-900">Delete Role</h3>
+            <div className="mt-2">
+              <p className="text-sm text-gray-500">
+                Are you sure you want to delete <strong>{role.name}</strong>? This action cannot be undone.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+          <button
+            onClick={onConfirm}
+            type="button"
+            className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 sm:ml-3 sm:w-auto sm:text-sm"
+          >
+            Delete
+          </button>
+          <button
+            onClick={onClose}
+            type="button"
+            className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:w-auto sm:text-sm"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default function AdminRolesPage() {
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [permissions, setPermissions] = useState<Permission[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<'add' | 'edit'>('add');
+  const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  const fetchData = async () => {
+    try {
+      const [rolesRes, permsRes] = await Promise.all([
+        api.get('/roles'),
+        api.get('/permissions'),
+      ]);
+      setRoles(rolesRes.data);
+      setPermissions(permsRes.data);
+    } catch {
+      toast.error('Failed to fetch roles or permissions.');
+    }
+  };
+
+  useEffect(() => {
+    if (!isLoading && user?.role.name !== 'ADMIN') {
+      toast.error("Access Denied: You don't have permission to view this page.");
+      router.push('/dashboard');
+      return;
+    }
+    if (user?.role.name === 'ADMIN') {
+      fetchData();
+    }
+  }, [user, isLoading, router]);
+
+  const openAddModal = () => {
+    setModalMode('add');
+    setSelectedRole(null);
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (role: Role) => {
+    setModalMode('edit');
+    setSelectedRole(role);
+    setIsModalOpen(true);
+  };
+
+  const handleAddOrUpdate = async (data: RoleFormInputs) => {
+    try {
+      if (modalMode === 'add') {
+        await api.post('/roles', data);
+        toast.success('Role created successfully!');
+      } else if (selectedRole) {
+        await api.patch(`/roles/${selectedRole.id}`, data);
+        toast.success('Role updated successfully!');
+      }
+      setIsModalOpen(false);
+      fetchData();
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || 'Failed to save role.');
+    }
+  };
+
+  const handleDelete = (role: Role) => {
+    setSelectedRole(role);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!selectedRole) return;
+    try {
+      await api.delete(`/roles/${selectedRole.id}`);
+      toast.success('Role deleted successfully.');
+      fetchData();
+      setIsDeleteModalOpen(false);
+      setSelectedRole(null);
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || 'Failed to delete role.');
+    }
+  };
+
+  if (isLoading || !user || user.role.name !== 'ADMIN') {
+    return <div className="flex items-center justify-center h-screen">Checking permissions...</div>;
+  }
+
+  return (
+    <>
+      <RoleModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={handleAddOrUpdate}
+        permissions={permissions}
+        defaultValues={
+          modalMode === 'edit' && selectedRole
+            ? { name: selectedRole.name, permissionIds: selectedRole.permissions.map((p) => p.id) }
+            : { name: '', permissionIds: [] }
+        }
+        title={modalMode === 'add' ? 'Add Role' : 'Edit Role'}
+        submitLabel={modalMode === 'add' ? 'Create' : 'Save'}
+      />
+      <DeleteRoleModal
+        role={selectedRole}
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+      />
+
+      <nav className="mb-4 space-x-4">
+        <Link href="/admin/users" className="text-blue-600 hover:underline">Users</Link>
+        <Link href="/admin/roles" className="text-blue-600 hover:underline">Roles</Link>
+        <Link href="/admin/permissions" className="text-blue-600 hover:underline">Permissions</Link>
+      </nav>
+
+      <div className="bg-white p-6 md:p-8 rounded-2xl shadow-lg w-full min-h-full">
+        <div className="flex flex-col md:flex-row justify-between items-center mb-8">
+          <h1 className="text-2xl font-bold mb-4 md:mb-0">Roles</h1>
+          <button
+            onClick={openAddModal}
+            className="w-full md:w-auto flex items-center justify-center bg-blue-600 text-white px-5 py-2 rounded-lg hover:bg-blue-700 font-semibold"
+          >
+            <PlusCircle className="w-5 h-5 mr-2" />
+            Add Role
+          </button>
+        </div>
+
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Permissions</th>
+              <th className="px-6 py-3" />
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {roles.map((r) => (
+              <tr key={r.id}>
+                <td className="px-6 py-4 whitespace-nowrap">{r.name}</td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  {r.permissions.map((p) => `${p.action} ${p.subject}`).join(', ')}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                  <button onClick={() => openEditModal(r)} className="text-indigo-600 hover:text-indigo-900"><Edit size={16} /></button>
+                  <button onClick={() => handleDelete(r)} className="text-red-600 hover:text-red-900"><Trash2 size={16} /></button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -168,6 +168,7 @@ export default function AdminUsersPage() {
       <DeleteConfirmationModal user={selectedUser} isOpen={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)} onConfirmDelete={handleConfirmDelete} />
       <nav className="mb-4 space-x-4">
         <Link href="/admin/users" className="text-blue-600 hover:underline">Users</Link>
+        <Link href="/admin/roles" className="text-blue-600 hover:underline">Roles</Link>
         <Link href="/admin/permissions" className="text-blue-600 hover:underline">Permissions</Link>
       </nav>
 


### PR DESCRIPTION
## Summary
- allow admins to create, update, and delete roles on the backend
- add admin UI for managing roles and their permissions
- link roles page into existing admin navigation

## Testing
- `npm test` (backend) *(fails: No tests found)*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d6317f94483238886dcc1e7033d19