### PR TITLE
feat: add comprehensive employee form

### DIFF
--- a/backend/prisma/migrations/20240613000000_add_employee/migration.sql
+++ b/backend/prisma/migrations/20240613000000_add_employee/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE `Employee` (
+    `employeeId` VARCHAR(191) NOT NULL,
+    `prefix` VARCHAR(191) NULL,
+    `firstName` VARCHAR(191) NULL,
+    `lastName` VARCHAR(191) NULL,
+    `age` INTEGER NULL,
+    `gender` VARCHAR(191) NULL,
+    `phone` VARCHAR(191) NULL,
+    `email` VARCHAR(191) NULL,
+    `birthDate` DATETIME(3) NULL,
+    `address` VARCHAR(191) NULL,
+    `subdistrict` VARCHAR(191) NULL,
+    `district` VARCHAR(191) NULL,
+    `province` VARCHAR(191) NULL,
+    `postalCode` VARCHAR(191) NULL,
+    `position` VARCHAR(191) NULL,
+    `department` VARCHAR(191) NULL,
+    `startDate` DATETIME(3) NULL,
+    `endDate` DATETIME(3) NULL,
+    `managerId` VARCHAR(191) NULL,
+    `status` VARCHAR(191) NULL,
+    `company` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    PRIMARY KEY (`employeeId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,10 +23,10 @@ model User {
 }
 
 model Role {
-  id          Int      @id @default(autoincrement())
-  name        String   @unique
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id          Int          @id @default(autoincrement())
+  name        String       @unique
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
   users       User[]
   permissions Permission[]
 }
@@ -40,4 +40,30 @@ model Permission {
   roles     Role[]
 
   @@unique([action, subject])
+}
+
+model Employee {
+  employeeId  String    @id
+  prefix      String?
+  firstName   String?
+  lastName    String?
+  age         Int?
+  gender      String?
+  phone       String?
+  email       String?
+  birthDate   DateTime?
+  address     String?
+  subdistrict String?
+  district    String?
+  province    String?
+  postalCode  String?
+  position    String?
+  department  String?
+  startDate   DateTime?
+  endDate     DateTime?
+  managerId   String?
+  status      String?
+  company     String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { RolesModule } from './roles/roles.module';
 import { PermissionsModule } from './permissions/permissions.module';
+import { EmployeesModule } from './employees/employees.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { PermissionsModule } from './permissions/permissions.module';
     UsersModule,
     RolesModule,
     PermissionsModule,
+    EmployeesModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/employees/dto/create-employee.dto.ts
+++ b/backend/src/employees/dto/create-employee.dto.ts
@@ -1,0 +1,91 @@
+import { IsString, IsOptional, IsInt, IsEmail, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateEmployeeDto {
+  @IsString()
+  employeeId: string;
+
+  @IsOptional()
+  @IsString()
+  prefix?: string;
+
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  age?: number;
+
+  @IsOptional()
+  @IsString()
+  gender?: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDateString()
+  birthDate?: Date;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  subdistrict?: string;
+
+  @IsOptional()
+  @IsString()
+  district?: string;
+
+  @IsOptional()
+  @IsString()
+  province?: string;
+
+  @IsOptional()
+  @IsString()
+  postalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsString()
+  department?: string;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDateString()
+  startDate?: Date;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDateString()
+  endDate?: Date;
+
+  @IsOptional()
+  @IsString()
+  managerId?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  company?: string;
+}

--- a/backend/src/employees/dto/update-employee.dto.ts
+++ b/backend/src/employees/dto/update-employee.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateEmployeeDto } from './create-employee.dto';
+
+export class UpdateEmployeeDto extends PartialType(CreateEmployeeDto) {}

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('employees')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('employees')
+export class EmployeesController {
+  constructor(private readonly employeesService: EmployeesService) {}
+
+  @Post()
+  @Roles('ADMIN')
+  create(@Body() createEmployeeDto: CreateEmployeeDto) {
+    return this.employeesService.create(createEmployeeDto);
+  }
+
+  @Get()
+  @Roles('ADMIN', 'MANAGER')
+  findAll() {
+    return this.employeesService.findAll();
+  }
+
+  @Get(':id')
+  @Roles('ADMIN', 'MANAGER')
+  findOne(@Param('id') id: string) {
+    return this.employeesService.findOne(id);
+  }
+
+  @Patch(':id')
+  @Roles('ADMIN')
+  update(@Param('id') id: string, @Body() updateEmployeeDto: UpdateEmployeeDto) {
+    return this.employeesService.update(id, updateEmployeeDto);
+  }
+
+  @Delete(':id')
+  @Roles('ADMIN')
+  remove(@Param('id') id: string) {
+    return this.employeesService.remove(id);
+  }
+}

--- a/backend/src/employees/employees.module.ts
+++ b/backend/src/employees/employees.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EmployeesService } from './employees.service';
+import { EmployeesController } from './employees.controller';
+
+@Module({
+  controllers: [EmployeesController],
+  providers: [EmployeesService],
+})
+export class EmployeesModule {}

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+
+@Injectable()
+export class EmployeesService {
+  constructor(private prisma: PrismaService) {}
+
+  create(createEmployeeDto: CreateEmployeeDto) {
+    return this.prisma.employee.create({ data: createEmployeeDto });
+  }
+
+  findAll() {
+    return this.prisma.employee.findMany();
+  }
+
+  async findOne(id: string) {
+    const employee = await this.prisma.employee.findUnique({ where: { employeeId: id } });
+    if (!employee) {
+      throw new NotFoundException(`Employee with ID ${id} not found`);
+    }
+    return employee;
+  }
+
+  update(id: string, updateEmployeeDto: UpdateEmployeeDto) {
+    return this.prisma.employee.update({ where: { employeeId: id }, data: updateEmployeeDto });
+  }
+
+  remove(id: string) {
+    return this.prisma.employee.delete({ where: { employeeId: id } });
+  }
+}

--- a/frontend/app/dashboard/employee/create/page.tsx
+++ b/frontend/app/dashboard/employee/create/page.tsx
@@ -5,66 +5,113 @@ import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
 import { toast } from 'sonner';
 import { ArrowLeft, Calendar as CalendarIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, ChangeEvent } from 'react';
 
-// --- Type Definitions ---
-interface Role {
+type Province = {
   id: number;
-  name: string;
-}
+  name_th: string;
+};
+
+type Amphure = {
+  id: number;
+  name_th: string;
+  province_id: number;
+};
+
+type Tambon = {
+  id: number;
+  name_th: string;
+  amphure_id: number;
+  zip_code: string;
+};
 
 type CreateEmployeeFormInputs = {
+  employeeId: string;
+  prefix: string;
   firstName: string;
   lastName: string;
-  employeeId: string;
-  birthDate: string;
   age: string;
   gender: string;
   phone: string;
   email: string;
-  department: string;
+  birthDate: string;
+  address: string;
+  subdistrict: string;
+  district: string;
+  province: string;
+  postalCode: string;
   position: string;
-  company: string;
-  loginEmail: string;
-  loginPassword: string;
-  accessRights: string;
+  department: string;
+  startDate: string;
+  endDate: string;
+  managerId: string;
   status: string;
-  roleId: number; // For system role
+  company: string;
 };
 
-// --- Main Page Component ---
 export default function CreateEmployeePage() {
   const router = useRouter();
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<CreateEmployeeFormInputs>();
-  const [roles, setRoles] = useState<Role[]>([]);
+  const { register, handleSubmit, setValue, formState: { isSubmitting } } = useForm<CreateEmployeeFormInputs>();
+  const [provinces, setProvinces] = useState<Province[]>([]);
+  const [amphures, setAmphures] = useState<Amphure[]>([]);
+  const [tambons, setTambons] = useState<Tambon[]>([]);
+  const [provinceId, setProvinceId] = useState<number>();
+  const [amphureId, setAmphureId] = useState<number>();
 
   useEffect(() => {
-    const fetchRoles = async () => {
+    const fetchAddress = async () => {
       try {
-        const response = await api.get('/roles');
-        setRoles(response.data);
+        const [pRes, aRes, tRes] = await Promise.all([
+          fetch('https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province.json'),
+          fetch('https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_amphure.json'),
+          fetch('https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_tambon.json'),
+        ]);
+        setProvinces(await pRes.json());
+        setAmphures(await aRes.json());
+        setTambons(await tRes.json());
       } catch (error) {
-        toast.error('Failed to fetch roles.');
+        toast.error('โหลดข้อมูลจังหวัดไม่สำเร็จ');
       }
     };
-    fetchRoles();
+    fetchAddress();
   }, []);
+
+  const filteredAmphures = amphures.filter(a => a.province_id === provinceId);
+  const filteredTambons = tambons.filter(t => t.amphure_id === amphureId);
 
   const onSubmit: SubmitHandler<CreateEmployeeFormInputs> = async (data) => {
     try {
-      // Map form data to the user creation DTO
-      const newUser = {
-        name: `${data.firstName} ${data.lastName}`,
-        email: data.loginEmail,
-        password: data.loginPassword,
-        roleId: Number(data.roleId),
-      };
-      await api.post('/users', newUser);
-      toast.success('Employee created successfully!');
-      router.push('/dashboard/employee'); // Redirect back to the employee list
+      await api.post('/employees', data);
+      toast.success('บันทึกพนักงานสำเร็จ');
+      router.push('/dashboard/employee');
     } catch (error: any) {
-      toast.error(error.response?.data?.message || 'Failed to create employee.');
+      toast.error(error.response?.data?.message || 'บันทึกพนักงานไม่สำเร็จ');
     }
+  };
+
+  const handleProvinceChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const id = Number(e.target.value);
+    setProvinceId(id);
+    setAmphureId(undefined);
+    setValue('province', e.target.options[e.target.selectedIndex].text);
+    setValue('district', '');
+    setValue('subdistrict', '');
+    setValue('postalCode', '');
+  };
+
+  const handleAmphureChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const id = Number(e.target.value);
+    setAmphureId(id);
+    setValue('district', e.target.options[e.target.selectedIndex].text);
+    setValue('subdistrict', '');
+    setValue('postalCode', '');
+  };
+
+  const handleTambonChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const id = Number(e.target.value);
+    const selected = tambons.find(t => t.id === id);
+    setValue('subdistrict', e.target.options[e.target.selectedIndex].text);
+    if (selected) setValue('postalCode', selected.zip_code.toString());
   };
 
   return (
@@ -77,51 +124,60 @@ export default function CreateEmployeePage() {
       </div>
 
       <form onSubmit={handleSubmit(onSubmit)}>
-        {/* General Information Section */}
         <div className="mb-8">
           <div className="bg-gray-200 text-gray-700 font-bold py-3 px-6 rounded-lg mb-6">
-            ข้อมูลทั่วไป
+            ข้อมูลพนักงาน
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            {/* Form Fields */}
-            <div><label className="block text-sm font-medium text-gray-700">ชื่อ *</label><input {...register("firstName", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">นามสกุล *</label><input {...register("lastName", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">รหัสพนักงาน</label><input {...register("employeeId")} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div className="relative"><label className="block text-sm font-medium text-gray-700">วันเกิด *</label><input type="date" {...register("birthDate", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /><CalendarIcon className="absolute right-3 top-9 text-gray-400" size={20} /></div>
-            <div><label className="block text-sm font-medium text-gray-700">อายุ</label><input {...register("age")} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">เพศ</label><select {...register("gender")} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option>กรุณาเลือก</option><option>ชาย</option><option>หญิง</option></select></div>
-            <div><label className="block text-sm font-medium text-gray-700">เบอร์โทรศัพท์</label><input {...register("phone")} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">อีเมล</label><input type="email" {...register("email")} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">แผนก *</label><select {...register("department", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option>กรุณาเลือก</option></select></div>
-            <div><label className="block text-sm font-medium text-gray-700">ตำแหน่ง *</label><select {...register("position", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option>กรุณาเลือก</option></select></div>
-            <div className="md:col-span-2"><label className="block text-sm font-medium text-gray-700">สังกัด บริษัท *</label><select {...register("company", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option>กรุณาเลือก</option></select></div>
-          </div>
-        </div>
-
-        {/* System Access Section */}
-        <div className="mb-8">
-          <div className="bg-gray-200 text-gray-700 font-bold py-3 px-6 rounded-lg mb-6">
-            ข้อมูลการเข้าระบบ
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            <div><label className="block text-sm font-medium text-gray-700">อีเมล *</label><input type="email" {...register("loginEmail", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">รหัสผ่าน *</label><input type="password" {...register("loginPassword", { required: true, minLength: 6 })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
-            <div><label className="block text-sm font-medium text-gray-700">สิทธิ์การใช้งาน *</label>
-              <select {...register("roleId", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white">
+            <div><label className="block text-sm font-medium text-gray-700">รหัสพนักงาน *</label><input {...register('employeeId', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">คำนำหน้า *</label><select {...register('prefix', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option value="">กรุณาเลือก</option><option>นาย</option><option>นาง</option><option>นางสาว</option></select></div>
+            <div><label className="block text-sm font-medium text-gray-700">ชื่อ *</label><input {...register('firstName', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">นามสกุล *</label><input {...register('lastName', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div className="relative"><label className="block text-sm font-medium text-gray-700">วันเกิด *</label><input type="date" {...register('birthDate', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /><CalendarIcon className="absolute right-3 top-9 text-gray-400" size={20} /></div>
+            <div><label className="block text-sm font-medium text-gray-700">อายุ</label><input {...register('age')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">เพศ</label><select {...register('gender')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option value="">กรุณาเลือก</option><option>ชาย</option><option>หญิง</option></select></div>
+            <div><label className="block text-sm font-medium text-gray-700">เบอร์โทรศัพท์</label><input {...register('phone')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">อีเมล</label><input type="email" {...register('email')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div className="md:col-span-2"><label className="block text-sm font-medium text-gray-700">ที่อยู่</label><input {...register('address')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">จังหวัด</label>
+              <select value={provinceId ?? ''} onChange={handleProvinceChange} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white">
                 <option value="">กรุณาเลือก</option>
-                {roles.map(role => (
-                  <option key={role.id} value={role.id}>{role.name}</option>
+                {provinces.map(p => (
+                  <option key={p.id} value={p.id}>{p.name_th}</option>
                 ))}
               </select>
             </div>
-            <div><label className="block text-sm font-medium text-gray-700">สถานะการเข้าระบบ *</label><select {...register("status", { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option>กรุณาเลือก</option><option>Active</option><option>Inactive</option></select></div>
+            <div><label className="block text-sm font-medium text-gray-700">อำเภอ</label>
+              <select value={amphureId ?? ''} onChange={handleAmphureChange} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white" disabled={!provinceId}>
+                <option value="">กรุณาเลือก</option>
+                {filteredAmphures.map(a => (
+                  <option key={a.id} value={a.id}>{a.name_th}</option>
+                ))}
+              </select>
+            </div>
+            <div><label className="block text-sm font-medium text-gray-700">ตำบล</label>
+              <select onChange={handleTambonChange} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white" disabled={!amphureId}>
+                <option value="">กรุณาเลือก</option>
+                {filteredTambons.map(t => (
+                  <option key={t.id} value={t.id}>{t.name_th}</option>
+                ))}
+              </select>
+            </div>
+            <div><label className="block text-sm font-medium text-gray-700">รหัสไปรษณีย์</label><input {...register('postalCode')} readOnly className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">ตำแหน่ง</label><input {...register('position')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">แผนก</label><input {...register('department')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">วันที่เริ่มงาน</label><input type="date" {...register('startDate')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">วันที่สิ้นสุดพนักงาน</label><input type="date" {...register('endDate')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">รหัสหัวหน้าพนักงาน</label><input {...register('managerId')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">สถานะพนักงาน</label><select {...register('status')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option value="">กรุณาเลือก</option><option>Active</option><option>Inactive</option></select></div>
+            <div><label className="block text-sm font-medium text-gray-700">บริษัท</label><input {...register('company')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
           </div>
         </div>
-        
+
         <div className="flex justify-center">
-            <button type="submit" disabled={isSubmitting} className="bg-blue-600 text-white font-bold py-3 px-12 rounded-lg hover:bg-blue-700 disabled:bg-blue-400">
-                {isSubmitting ? 'กำลังบันทึก...' : 'บันทึก'}
-            </button>
+          <button type="submit" disabled={isSubmitting} className="bg-blue-600 text-white font-bold py-3 px-12 rounded-lg hover:bg-blue-700 disabled:bg-blue-400">
+            {isSubmitting ? 'กำลังบันทึก...' : 'บันทึก'}
+          </button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add full employee creation form with address hierarchy and status fields
- filter districts and subdistricts based on selected province
- implement backend employee module with Prisma model and CRUD endpoints

## Testing
- `DATABASE_URL="mysql://root:root@localhost:3306/test" npx prisma migrate dev --name add_employee --create-only` *(fails: Can't reach database server at `localhost:3306`)*
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_689d843269588323ac61b2979bbf7fbd