### PR TITLE
Integrate employee data into user table and enforce account status

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,12 +11,33 @@ datasource db {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  password  String
-  name      String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             Int      @id @default(autoincrement())
+  employeeId     String   @unique
+  email          String   @unique
+  password       String
+  name           String?
+  prefix         String?
+  firstName      String?
+  lastName       String?
+  age            Int?
+  gender         String?
+  phone          String?
+  birthDate      DateTime?
+  address        String?
+  subdistrict    String?
+  district       String?
+  province       String?
+  postalCode     String?
+  position       String?
+  department     String?
+  startDate      DateTime?
+  endDate        DateTime?
+  managerId      String?
+  status         String?  @default("Active")
+  company        String?
+  responsibleArea String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   role   Role @relation(fields: [roleId], references: [id])
   roleId Int
@@ -40,30 +61,4 @@ model Permission {
   roles     Role[]
 
   @@unique([action, subject])
-}
-
-model Employee {
-  employeeId  String    @id
-  prefix      String?
-  firstName   String?
-  lastName    String?
-  age         Int?
-  gender      String?
-  phone       String?
-  email       String?
-  birthDate   DateTime?
-  address     String?
-  subdistrict String?
-  district    String?
-  province    String?
-  postalCode  String?
-  position    String?
-  department  String?
-  startDate   DateTime?
-  endDate     DateTime?
-  managerId   String?
-  status      String?
-  company     String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -32,6 +32,7 @@ export class AuthService {
     if (!user) throw new UnauthorizedException('Invalid credentials');
     const isMatch = await bcrypt.compare(loginDto.password, user.password);
     if (!isMatch) throw new UnauthorizedException('Invalid credentials');
+    if (user.status && user.status.toLowerCase() === 'inactive') throw new UnauthorizedException('User inactive');
     return this.generateTokens(user.id, user.email, user.role.name);
   }
 

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,11 +1,17 @@
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 export class RegisterDto {
+  @IsString()
+  @IsNotEmpty()
+  employeeId: string;
+
   @IsEmail()
   email: string;
+
   @IsString()
   @IsNotEmpty()
   @MinLength(6)
   password: string;
+
   @IsString()
   @IsNotEmpty()
   name: string;

--- a/backend/src/employees/dto/create-employee.dto.ts
+++ b/backend/src/employees/dto/create-employee.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsInt, IsEmail, IsDateString } from 'class-validator';
+import { IsString, IsOptional, IsInt, IsEmail, IsDateString, MinLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateEmployeeDto {
@@ -30,9 +30,12 @@ export class CreateEmployeeDto {
   @IsString()
   phone?: string;
 
-  @IsOptional()
   @IsEmail()
-  email?: string;
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
 
   @IsOptional()
   @IsDateString()
@@ -85,4 +88,8 @@ export class CreateEmployeeDto {
   @IsOptional()
   @IsString()
   company?: string;
+
+  @IsOptional()
+  @IsString()
+  responsibleArea?: string;
 }

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -2,32 +2,49 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateEmployeeDto } from './dto/create-employee.dto';
 import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class EmployeesService {
   constructor(private prisma: PrismaService) {}
 
-  create(createEmployeeDto: CreateEmployeeDto) {
-    return this.prisma.employee.create({ data: createEmployeeDto });
+  async create(createEmployeeDto: CreateEmployeeDto) {
+    const { password, ...data } = createEmployeeDto;
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const userRole = await this.prisma.role.findUnique({ where: { name: 'USER' } });
+    if (!userRole) throw new Error('Default USER role not found');
+    const user = await this.prisma.user.create({
+      data: {
+        ...data,
+        password: hashedPassword,
+        roleId: userRole.id,
+      },
+    });
+    const { password: _pwd, ...result } = user;
+    return result;
   }
 
   findAll() {
-    return this.prisma.employee.findMany();
+    return this.prisma.user.findMany();
   }
 
   async findOne(id: string) {
-    const employee = await this.prisma.employee.findUnique({ where: { employeeId: id } });
+    const employee = await this.prisma.user.findUnique({ where: { employeeId: id } });
     if (!employee) {
       throw new NotFoundException(`Employee with ID ${id} not found`);
     }
     return employee;
   }
 
-  update(id: string, updateEmployeeDto: UpdateEmployeeDto) {
-    return this.prisma.employee.update({ where: { employeeId: id }, data: updateEmployeeDto });
+  async update(id: string, updateEmployeeDto: UpdateEmployeeDto) {
+    const data: any = { ...updateEmployeeDto };
+    if (updateEmployeeDto.password) {
+      data.password = await bcrypt.hash(updateEmployeeDto.password, 10);
+    }
+    return this.prisma.user.update({ where: { employeeId: id }, data });
   }
 
   remove(id: string) {
-    return this.prisma.employee.delete({ where: { employeeId: id } });
+    return this.prisma.user.delete({ where: { employeeId: id } });
   }
 }

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,14 +1,29 @@
-import { IsEmail, IsNotEmpty, IsNumber, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsNumber, IsString, MinLength, IsOptional } from 'class-validator';
 export class CreateUserDto {
+  @IsString()
+  @IsNotEmpty()
+  employeeId: string;
+
   @IsEmail()
   email: string;
+
   @IsString()
   @IsNotEmpty()
   @MinLength(6)
   password: string;
+
   @IsString()
   @IsNotEmpty()
   name: string;
+
   @IsNumber()
   roleId: number;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  responsibleArea?: string;
 }

--- a/frontend/app/dashboard/employee/create/page.tsx
+++ b/frontend/app/dashboard/employee/create/page.tsx
@@ -34,6 +34,7 @@ type CreateEmployeeFormInputs = {
   gender: string;
   phone: string;
   email: string;
+  password: string;
   birthDate: string;
   address: string;
   subdistrict: string;
@@ -47,6 +48,7 @@ type CreateEmployeeFormInputs = {
   managerId: string;
   status: string;
   company: string;
+  responsibleArea: string;
 };
 
 export default function CreateEmployeePage() {
@@ -146,6 +148,7 @@ export default function CreateEmployeePage() {
             <div><label className="block text-sm font-medium text-gray-700">เพศ</label><select {...register('gender')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option value="">กรุณาเลือก</option><option>ชาย</option><option>หญิง</option></select></div>
             <div><label className="block text-sm font-medium text-gray-700">เบอร์โทรศัพท์</label><input {...register('phone')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
             <div><label className="block text-sm font-medium text-gray-700">อีเมล *</label><input type="email" {...register('email', { required: true })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">รหัสผ่าน *</label><input type="password" {...register('password', { required: true, minLength: 6 })} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
             <div className="md:col-span-2"><label className="block text-sm font-medium text-gray-700">ที่อยู่</label><input {...register('address')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
             <div><label className="block text-sm font-medium text-gray-700">จังหวัด</label>
               <select value={provinceId ?? ''} onChange={handleProvinceChange} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white">
@@ -179,6 +182,7 @@ export default function CreateEmployeePage() {
             <div><label className="block text-sm font-medium text-gray-700">รหัสหัวหน้าพนักงาน</label><input {...register('managerId')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
             <div><label className="block text-sm font-medium text-gray-700">สถานะพนักงาน</label><select {...register('status')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-white"><option value="">กรุณาเลือก</option><option>Active</option><option>Inactive</option></select></div>
             <div><label className="block text-sm font-medium text-gray-700">บริษัท</label><input {...register('company')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
+            <div><label className="block text-sm font-medium text-gray-700">เขตรับผิดชอบ</label><input {...register('responsibleArea')} className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md" /></div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Merge employee fields into User schema and remove separate Employee model
- Ensure login fails for inactive users
- Create employees as Users with password hashing and responsible area
- Extend employee creation UI to capture user password and responsible area

## Testing
- `npm test` (backend) *(fails: No tests found)*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e957dbbe48323b07afb3ca1741016