### PR TITLE
feat: add role-based menu visibility

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -42,6 +42,24 @@ async function main() {
     },
   });
 
+  const extraRoles = [
+    'CEO',
+    'MARKETING_MANAGER',
+    'MARKETING_HEAD',
+    'MARKETING_EMPLOYEE',
+    'SALES_MANAGER',
+    'SALES_HEAD',
+    'SALES_EMPLOYEE',
+  ];
+
+  for (const name of extraRoles) {
+    await prisma.role.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
   // --- Create Users ---
   const passwordHash = await bcrypt.hash('admin@example.com', 10);
 

--- a/frontend/app/dashboard/_components/Sidebar.tsx
+++ b/frontend/app/dashboard/_components/Sidebar.tsx
@@ -52,6 +52,16 @@ const navItems = [
 
 ];
 
+// Restrict menu visibility based on role
+const roleMenuRestrictions: Record<string, string[]> = {
+  MARKETING_MANAGER: ["/dashboard/sales"],
+  MARKETING_HEAD: ["/dashboard", "/dashboard/sales"],
+  MARKETING_EMPLOYEE: ["/dashboard", "/dashboard/sales"],
+  SALES_MANAGER: ["/dashboard/marketing"],
+  SALES_HEAD: ["/dashboard", "/dashboard/marketing"],
+  SALES_EMPLOYEE: ["/dashboard", "/dashboard/marketing"],
+};
+
 const Logo = () => (
   <div className="bg-red-650 p-4 flex items-center justify-center mb-6 mr-5 mt-4">
     <div className="relative w-36 h-36 rounded-lg overflow-hidden p-2">
@@ -154,10 +164,15 @@ export default function Sidebar({
   const { user } = useAuth();
 
   const filteredNavItems = navItems.filter((item) => {
+    const roleName = user?.role.name;
+
     if (item.href.startsWith("/admin")) {
-      return user?.role.name === "ADMIN";
+      return roleName === "ADMIN" || roleName === "CEO";
     }
-    return true;
+
+    const restricted =
+      roleMenuRestrictions[roleName as keyof typeof roleMenuRestrictions] || [];
+    return !restricted.includes(item.href);
   });
 
   // This effect ensures the correct submenu is open based on the current URL


### PR DESCRIPTION
## Summary
- restrict sales, marketing, and report menus by role
- seed database with CEO, marketing, and sales roles

## Testing
- `npm --prefix backend test` *(fails: No tests found, exiting with code 1)*
- `npm --prefix backend run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm --prefix frontend run lint` *(fails: Requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689eb00ff9e0832380c39ab8ec34ccba