### PR TITLE
feat: add role-based CRUD permissions

### DIFF
--- a/frontend/app/admin/users/[id]/permissions/page.tsx
+++ b/frontend/app/admin/users/[id]/permissions/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import api from "@/lib/api";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import Link from "next/link";
+
+interface Role {
+  id: number;
+  name: string;
+}
+
+interface User {
+  id: number;
+  name: string;
+  role: Role;
+}
+
+export default function EditUserPermissions({ params }: { params: { id: string } }) {
+  const { user: currentUser, isLoading } = useAuth();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [roleId, setRoleId] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (currentUser?.role.name !== "ADMIN") {
+        router.push("/dashboard");
+        return;
+      }
+      const fetchData = async () => {
+        const [userRes, rolesRes] = await Promise.all([
+          api.get(`/users/${params.id}`),
+          api.get("/roles"),
+        ]);
+        setUser(userRes.data);
+        setRoleId(userRes.data.role.id);
+        setRoles(rolesRes.data);
+      };
+      fetchData();
+    }
+  }, [currentUser, isLoading, params.id, router]);
+
+  const handleSave = async () => {
+    try {
+      await api.patch(`/users/${params.id}`, { roleId });
+      toast.success("อัปเดตสิทธิ์เรียบร้อยแล้ว");
+    } catch (err: any) {
+      toast.error(err.response?.data?.message || "ไม่สามารถอัปเดตสิทธิ์ได้");
+    }
+  };
+
+  if (isLoading || !currentUser || currentUser.role.name !== "ADMIN" || !user) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">แก้ไขสิทธิ์: {user.name}</h1>
+      <select
+        value={roleId}
+        onChange={(e) => setRoleId(Number(e.target.value))}
+        className="border px-4 py-2 rounded"
+      >
+        {roles.map((r) => (
+          <option key={r.id} value={r.id}>
+            {r.name}
+          </option>
+        ))}
+      </select>
+      <div className="space-x-2">
+        <button
+          onClick={handleSave}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          บันทึก
+        </button>
+        <Link
+          href="/admin/users"
+          className="bg-gray-200 text-gray-700 px-4 py-2 rounded"
+        >
+          ย้อนกลับ
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -178,6 +178,7 @@ const UserCard = ({ user, onEdit, onDelete }: { user: User; onEdit: () => void; 
             <p className="text-sm text-gray-500 mb-4">{user.role.name === 'USER' ? 'เซลล์' : user.role.name}</p>
             <div className="flex space-x-2 mb-6">
                 <button onClick={onEdit} className="bg-gray-200 text-gray-700 text-xs font-semibold px-4 py-1.5 rounded-lg hover:bg-gray-300">แก้ไข</button>
+                <Link href={`/admin/users/${user.id}/permissions`} className="bg-gray-200 text-gray-700 text-xs font-semibold px-4 py-1.5 rounded-lg hover:bg-gray-300">สิทธิ์</Link>
                 <button className="bg-gray-200 text-gray-700 text-xs font-semibold px-4 py-1.5 rounded-lg hover:bg-gray-300">รายละเอียด</button>
             </div>
             <div className="w-full flex justify-around border-t border-gray-200 pt-4">

--- a/frontend/app/dashboard/_components/Sidebar.tsx
+++ b/frontend/app/dashboard/_components/Sidebar.tsx
@@ -52,6 +52,16 @@ const navItems = [
 
 ];
 
+// Restrict menu visibility based on role
+const roleMenuRestrictions: Record<string, string[]> = {
+  MARKETING_MANAGER: ["/dashboard/sales"],
+  MARKETING_HEAD: ["/dashboard", "/dashboard/sales"],
+  MARKETING_EMPLOYEE: ["/dashboard", "/dashboard/sales"],
+  SALES_MANAGER: ["/dashboard/marketing"],
+  SALES_HEAD: ["/dashboard", "/dashboard/marketing"],
+  SALES_EMPLOYEE: ["/dashboard", "/dashboard/marketing"],
+};
+
 const Logo = () => (
   <div className="bg-red-650 p-4 flex items-center justify-center mb-6 mr-5 mt-4">
     <div className="relative w-36 h-36 rounded-lg overflow-hidden p-2">
@@ -154,10 +164,15 @@ export default function Sidebar({
   const { user } = useAuth();
 
   const filteredNavItems = navItems.filter((item) => {
+    const roleName = user?.role.name;
+
     if (item.href.startsWith("/admin")) {
-      return user?.role.name === "ADMIN";
+      return roleName === "ADMIN" || roleName === "CEO";
     }
-    return true;
+
+    const restricted =
+      roleMenuRestrictions[roleName as keyof typeof roleMenuRestrictions] || [];
+    return !restricted.includes(item.href);
   });
 
   // This effect ensures the correct submenu is open based on the current URL

--- a/frontend/app/dashboard/marketing/page.tsx
+++ b/frontend/app/dashboard/marketing/page.tsx
@@ -1,8 +1,29 @@
-// frontend/app/dashboard/map/page.tsx
-export default function MapPage() {
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
+
+export default function MarketingPage() {
+  const { user } = useAuth();
+
+  const hasPermission = (action: string) =>
+    user?.role.permissions.some(
+      (p: any) => p.action === action && p.subject === "marketing"
+    );
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">การตลาด</h1>
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">การตลาด</h1>
+      <div className="space-x-2">
+        {hasPermission("create") && (
+          <button className="bg-blue-600 text-white px-4 py-2 rounded">สร้าง</button>
+        )}
+        {hasPermission("update") && (
+          <button className="bg-yellow-500 text-white px-4 py-2 rounded">แก้ไข</button>
+        )}
+        {hasPermission("delete") && (
+          <button className="bg-red-600 text-white px-4 py-2 rounded">ลบ</button>
+        )}
+      </div>
       <p>หน้านี้จะแสดงข้อมูลการตลาด (กำลังพัฒนา)</p>
     </div>
   );

--- a/frontend/app/dashboard/sales/orders/page.tsx
+++ b/frontend/app/dashboard/sales/orders/page.tsx
@@ -1,11 +1,29 @@
-'use client';
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
 
 export default function SalesOrdersPage() {
+  const { user } = useAuth();
+
+  const hasPermission = (action: string) =>
+    user?.role.permissions.some(
+      (p: any) => p.action === action && p.subject === "sales"
+    );
+
   return (
-    <div className="bg-white w-full min-h-full rounded-2xl shadow-lg p-6 md:p-8">
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">
-        รายการขาย (Sales Orders)
-      </h1>
+    <div className="bg-white w-full min-h-full rounded-2xl shadow-lg p-6 md:p-8 space-y-4">
+      <h1 className="text-3xl font-bold text-gray-800">รายการขาย (Sales Orders)</h1>
+      <div className="space-x-2">
+        {hasPermission("create") && (
+          <button className="bg-blue-600 text-white px-4 py-2 rounded">สร้าง</button>
+        )}
+        {hasPermission("update") && (
+          <button className="bg-yellow-500 text-white px-4 py-2 rounded">แก้ไข</button>
+        )}
+        {hasPermission("delete") && (
+          <button className="bg-red-600 text-white px-4 py-2 rounded">ลบ</button>
+        )}
+      </div>
       <p>เนื้อหาของหน้ารายการขายจะแสดงที่นี่...</p>
       {/* You can add a table or list of sales orders here later */}
     </div>


### PR DESCRIPTION
## Summary
- seed CRUD permissions for marketing and sales roles
- show create/update/delete buttons based on role
- add user permissions editor page

## Testing
- `npm --prefix backend test` *(fails: No tests found, exiting with code 1)*
- `npm --prefix backend run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm --prefix frontend run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689eb00ff9e0832380c39ab8ec34ccba