### PR TITLE
feat: add Thai address picker

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -62,3 +62,25 @@ model Permission {
 
   @@unique([action, subject])
 }
+
+model Province {
+  id       Int      @id
+  name_th  String
+  amphures Amphure[]
+}
+
+model Amphure {
+  id          Int       @id
+  name_th     String
+  province_id Int
+  province    Province  @relation(fields: [province_id], references: [id])
+  tambons     Tambon[]
+}
+
+model Tambon {
+  id         Int      @id
+  name_th    String
+  amphure_id Int
+  zip_code   Int?
+  amphure    Amphure  @relation(fields: [amphure_id], references: [id])
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -7,6 +7,42 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('🌱 Seeding database...');
 
+  const [provinceData, amphureData, tambonData] = await Promise.all([
+    fetch(
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province.json'
+    ).then((r) => r.json()),
+    fetch(
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_amphure.json'
+    ).then((r) => r.json()),
+    fetch(
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_tambon.json'
+    ).then((r) => r.json()),
+  ]);
+
+  await prisma.province.createMany({
+    data: provinceData.map((p: any) => ({ id: p.id, name_th: p.name_th })),
+    skipDuplicates: true,
+  });
+
+  await prisma.amphure.createMany({
+    data: amphureData.map((a: any) => ({
+      id: a.id,
+      name_th: a.name_th,
+      province_id: a.province_id,
+    })),
+    skipDuplicates: true,
+  });
+
+  await prisma.tambon.createMany({
+    data: tambonData.map((t: any) => ({
+      id: t.id,
+      name_th: t.name_th,
+      amphure_id: t.amphure_id,
+      zip_code: t.zip_code,
+    })),
+    skipDuplicates: true,
+  });
+
   const actions = ['create', 'read', 'update', 'delete'];
   const subjects = ['user', 'marketing', 'sales', 'report'];
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { UsersModule } from './users/users.module';
 import { RolesModule } from './roles/roles.module';
 import { PermissionsModule } from './permissions/permissions.module';
 import { EmployeesModule } from './employees/employees.module';
+import { ThaiAddressModule } from './thai-address/thai-address.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { EmployeesModule } from './employees/employees.module';
     RolesModule,
     PermissionsModule,
     EmployeesModule,
+    ThaiAddressModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/thai-address/thai-address.controller.ts
+++ b/backend/src/thai-address/thai-address.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ThaiAddressService } from './thai-address.service';
+
+@Controller('thai-address')
+export class ThaiAddressController {
+  constructor(private readonly service: ThaiAddressService) {}
+
+  @Get('provinces')
+  getProvinces() {
+    return this.service.provinces();
+  }
+
+  @Get('amphures')
+  getAmphures(@Query('provinceId') provinceId: string) {
+    return this.service.amphures(Number(provinceId));
+  }
+
+  @Get('tambons')
+  getTambons(@Query('amphureId') amphureId: string) {
+    return this.service.tambons(Number(amphureId));
+  }
+}

--- a/backend/src/thai-address/thai-address.module.ts
+++ b/backend/src/thai-address/thai-address.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ThaiAddressService } from './thai-address.service';
+import { ThaiAddressController } from './thai-address.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ThaiAddressService],
+  controllers: [ThaiAddressController],
+})
+export class ThaiAddressModule {}

--- a/backend/src/thai-address/thai-address.service.ts
+++ b/backend/src/thai-address/thai-address.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ThaiAddressService {
+  constructor(private prisma: PrismaService) {}
+
+  provinces() {
+    return this.prisma.province.findMany({ orderBy: { id: 'asc' } });
+  }
+
+  amphures(provinceId: number) {
+    return this.prisma.amphure.findMany({
+      where: { province_id: provinceId },
+      orderBy: { id: 'asc' },
+    });
+  }
+
+  tambons(amphureId: number) {
+    return this.prisma.tambon.findMany({
+      where: { amphure_id: amphureId },
+      orderBy: { id: 'asc' },
+    });
+  }
+}

--- a/frontend/components/ThaiAddressPicker.tsx
+++ b/frontend/components/ThaiAddressPicker.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import api from "@/lib/api";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+
+type Province = { id: number; name_th: string };
+type Amphure = { id: number; name_th: string; province_id: number };
+type Tambon = {
+  id: number;
+  name_th: string;
+  amphure_id: number;
+  zip_code: number;
+};
+
+interface Props {
+  register: any;
+  setValue: (name: string, value: any, options?: any) => void;
+  defaultValues?: {
+    province?: string;
+    district?: string;
+    subdistrict?: string;
+    postalCode?: string;
+  };
+}
+
+export default function ThaiAddressPicker({
+  register,
+  setValue,
+  defaultValues,
+}: Props) {
+  const [provinces, setProvinces] = useState<Province[]>([]);
+  const [amphures, setAmphures] = useState<Amphure[]>([]);
+  const [tambons, setTambons] = useState<Tambon[]>([]);
+  const [provinceId, setProvinceId] = useState<number>();
+  const [amphureId, setAmphureId] = useState<number>();
+
+  useEffect(() => {
+    api.get("/thai-address/provinces").then((res) => setProvinces(res.data));
+  }, []);
+
+  useEffect(() => {
+    if (provinceId) {
+      api
+        .get("/thai-address/amphures", { params: { provinceId } })
+        .then((res) => setAmphures(res.data));
+    }
+  }, [provinceId]);
+
+  useEffect(() => {
+    if (amphureId) {
+      api
+        .get("/thai-address/tambons", { params: { amphureId } })
+        .then((res) => setTambons(res.data));
+    }
+  }, [amphureId]);
+
+  useEffect(() => {
+    if (defaultValues) {
+      if (defaultValues.province) setValue("province", defaultValues.province);
+      if (defaultValues.district) setValue("district", defaultValues.district);
+      if (defaultValues.subdistrict)
+        setValue("subdistrict", defaultValues.subdistrict);
+      if (defaultValues.postalCode)
+        setValue("postalCode", defaultValues.postalCode);
+    }
+  }, [defaultValues, setValue]);
+
+  useEffect(() => {
+    if (defaultValues?.province && provinces.length) {
+      const p = provinces.find((p) => p.name_th === defaultValues.province);
+      if (p) setProvinceId(p.id);
+    }
+  }, [defaultValues?.province, provinces]);
+
+  useEffect(() => {
+    if (defaultValues?.district && amphures.length) {
+      const a = amphures.find((a) => a.name_th === defaultValues.district);
+      if (a) setAmphureId(a.id);
+    }
+  }, [defaultValues?.district, amphures]);
+
+  useEffect(() => {
+    if (defaultValues?.subdistrict && tambons.length) {
+      const t = tambons.find((t) => t.name_th === defaultValues.subdistrict);
+      if (t) setValue("postalCode", t.zip_code.toString());
+    }
+  }, [defaultValues?.subdistrict, tambons, setValue]);
+
+  const handleProvinceChange = (value: string) => {
+    const id = Number(value);
+    setProvinceId(id);
+    setAmphureId(undefined);
+    setTambons([]);
+    const found = provinces.find((p) => p.id === id);
+    setValue("province", found ? found.name_th : "");
+    setValue("district", "");
+    setValue("subdistrict", "");
+    setValue("postalCode", "");
+  };
+
+  const handleAmphureChange = (value: string) => {
+    const id = Number(value);
+    setAmphureId(id);
+    const found = amphures.find((a) => a.id === id);
+    setValue("district", found ? found.name_th : "");
+    setValue("subdistrict", "");
+    setValue("postalCode", "");
+  };
+
+  const handleTambonChange = (value: string) => {
+    const id = Number(value);
+    const found = tambons.find((t) => t.id === id);
+    setValue("subdistrict", found ? found.name_th : "");
+    setValue("postalCode", found ? found.zip_code.toString() : "");
+  };
+
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          จังหวัด
+        </label>
+        <Select onValueChange={handleProvinceChange} value={provinceId?.toString()}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="กรุณาเลือก" />
+          </SelectTrigger>
+          <SelectContent>
+            {provinces.map((p) => (
+              <SelectItem key={p.id} value={String(p.id)}>
+                {p.name_th}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input type="hidden" {...register("province")} />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          อำเภอ
+        </label>
+        <Select
+          onValueChange={handleAmphureChange}
+          value={amphureId?.toString()}
+          disabled={!provinceId}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="กรุณาเลือก" />
+          </SelectTrigger>
+          <SelectContent>
+            {amphures.map((a) => (
+              <SelectItem key={a.id} value={String(a.id)}>
+                {a.name_th}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input type="hidden" {...register("district")} />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          ตำบล
+        </label>
+        <Select onValueChange={handleTambonChange} disabled={!amphureId}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="กรุณาเลือก" />
+          </SelectTrigger>
+          <SelectContent>
+            {tambons.map((t) => (
+              <SelectItem key={t.id} value={String(t.id)}>
+                {t.name_th}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input type="hidden" {...register("subdistrict")} />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          รหัสไปรษณีย์
+        </label>
+        <Input
+          {...register("postalCode")}
+          readOnly
+          className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100"
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- store Thai provinces, amphures, tambons in database and expose endpoints
- add ThaiAddressPicker component with shadcn select inputs
- use ThaiAddressPicker on employee create and edit pages

## Testing
- `npx prisma generate`
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ea2bce208323b3562c6af4f42acc