### PR TITLE
Ensure header visible when editing employees

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import Sidebar from './_components/Sidebar';
 import Header from './_components/Header';
 import { useAuth } from '@/context/AuthContext';
+import { usePathname } from 'next/navigation';
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   const { user, isLoading } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const main = document.querySelector('main');
+    main?.scrollTo({ top: 0 });
+  }, [pathname]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- Reset dashboard main scroll position on route changes to keep header visible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a80b6ad3248323a563f7628b8caf3e