### PR TITLE
Enable employee ID/email editing and add pagination

### DIFF
--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -77,8 +77,32 @@ export class EmployeesService {
   }
 
   async update(id: string, updateEmployeeDto: UpdateEmployeeDto) {
-    const { password, firstName, lastName, ...rest } = updateEmployeeDto;
+    const { employeeId, email, password, firstName, lastName, ...rest } =
+      updateEmployeeDto;
     const data: any = { ...rest };
+
+    if (employeeId && employeeId !== id) {
+      const existEmpId = await this.prisma.user.findUnique({
+        where: { employeeId },
+      });
+      if (existEmpId) {
+        throw new BadRequestException(
+          `รหัสพนักงาน ${employeeId} ถูกใช้งานแล้ว`,
+        );
+      }
+      data.employeeId = employeeId;
+    }
+
+    if (email) {
+      const existEmail = await this.prisma.user.findUnique({
+        where: { email },
+      });
+      if (existEmail && existEmail.employeeId !== id) {
+        throw new BadRequestException(`อีเมล ${email} ถูกใช้งานแล้ว`);
+      }
+      data.email = email;
+    }
+
     if (password) {
       data.password = await bcrypt.hash(password, 10);
     }

--- a/frontend/app/dashboard/employee/[id]/edit/page.tsx
+++ b/frontend/app/dashboard/employee/[id]/edit/page.tsx
@@ -213,14 +213,10 @@ export default function EditEmployeePage() {
                 รหัสพนักงาน *
               </label>
               <Input
-                readOnly
                 {...register("employeeId", {
                   required: "กรุณากรอกรหัสพนักงาน",
                 })}
-                className={cn(
-                  "bg-gray-100 text-gray-700 cursor-not-allowed",
-                  errors.employeeId && "border-red-500"
-                )}
+                className={cn(errors.employeeId && "border-red-500")}
               />
               {errors.employeeId && (
                 <p className="flex items-center mt-1 text-xs text-red-500">
@@ -669,10 +665,15 @@ export default function EditEmployeePage() {
               </label>
               <Input
                 type="email"
-                readOnly
                 {...register("email", { required: "กรุณากรอกอีเมล" })}
-                className={cn("bg-gray-100 text-gray-700 cursor-not-allowed")}
+                className={cn(errors.email && "border-red-500")}
               />
+              {errors.email && (
+                <p className="flex items-center mt-1 text-xs text-red-500">
+                  <AlertTriangle size={14} className="mr-1" />
+                  {errors.email.message as string}
+                </p>
+              )}
             </div>
 
             {/* รหัสผ่านใหม่ */}

--- a/frontend/app/dashboard/employee/[id]/page.tsx
+++ b/frontend/app/dashboard/employee/[id]/page.tsx
@@ -71,7 +71,7 @@ const mockActivities = [
 
 // --- Left Panel Component ---
 const UserProfilePanel = ({ user }: { user: User }) => (
-  <div className="w-full lg:w-1/4 xl:w-1/5 bg-white rounded-2xl shadow-lg p-6 self-start sticky top-8">
+  <div className="w-full lg:w-1/4 xl:w-1/5 bg-white rounded-2xl shadow-lg p-6 self-start lg:sticky lg:top-8">
     <div className="flex flex-col items-center text-center">
       <div className="relative w-28 h-28 rounded-full overflow-hidden mb-4 border-4 border-gray-200">
         <Image
@@ -161,7 +161,7 @@ const ActivityCard = ({
       </div>
       <div className="w-full md:w-2/3 border-t md:border-t-0 md:border-l border-gray-200 md:pl-6 pt-4 md:pt-0">
         <p className="font-bold text-gray-800 mb-2">ข้อมูล</p>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
           <div>
             <p className="text-gray-500">รายรับ</p>
             <p className="font-bold text-gray-900">
@@ -238,7 +238,7 @@ export default function UserDetailPage() {
   }
 
   return (
-    <div className="flex flex-col lg:flex-row gap-8">
+    <div className="flex flex-col lg:flex-row gap-8 p-4 md:p-8">
       <UserProfilePanel user={user} />
 
       <div className="w-full lg:flex-1">

--- a/frontend/app/dashboard/employee/page.tsx
+++ b/frontend/app/dashboard/employee/page.tsx
@@ -153,6 +153,8 @@ export default function EmployeePage() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 8;
 
   const { user: currentUser, isLoading } = useAuth();
   const router = useRouter();
@@ -178,6 +180,10 @@ export default function EmployeePage() {
       fetchData();
     }
   }, [currentUser, isLoading, router]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm]);
 
   const handleDelete = (user: User) => {
     setSelectedUser(user);
@@ -209,6 +215,15 @@ export default function EmployeePage() {
       u.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       u.email.toLowerCase().includes(searchTerm.toLowerCase())
   );
+
+  const totalPages = Math.ceil(filteredUsers.length / itemsPerPage) || 1;
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const currentUsers = filteredUsers.slice(
+    startIndex,
+    startIndex + itemsPerPage
+  );
+  const startDisplay = filteredUsers.length ? startIndex + 1 : 0;
+  const endDisplay = Math.min(startIndex + itemsPerPage, filteredUsers.length);
 
   return (
     <>
@@ -246,7 +261,7 @@ export default function EmployeePage() {
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
-          {filteredUsers.map((user) => (
+          {currentUsers.map((user) => (
             <UserCard
               key={user.id}
               user={user}
@@ -256,12 +271,24 @@ export default function EmployeePage() {
         </div>
 
         <div className="flex justify-between items-center mt-8 text-sm text-gray-600">
-          <p>1-8 of 28</p>
+          <p>
+            {startDisplay}-{endDisplay} of {filteredUsers.length}
+          </p>
           <div className="flex items-center space-x-2">
-            <button className="p-2 rounded-md hover:bg-gray-100">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+              disabled={currentPage === 1}
+              className="p-2 rounded-md hover:bg-gray-100 disabled:opacity-50"
+            >
               <ChevronLeft size={20} />
             </button>
-            <button className="p-2 rounded-md hover:bg-gray-100">
+            <button
+              onClick={() =>
+                setCurrentPage((p) => Math.min(p + 1, totalPages))
+              }
+              disabled={currentPage === totalPages}
+              className="p-2 rounded-md hover:bg-gray-100 disabled:opacity-50"
+            >
               <ChevronRight size={20} />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Allow editing employee ID and email with validation
- Add client-side pagination to employee dashboard
- Reject updates that reuse existing employee IDs or emails and return clear error messages
- Make employee detail page responsive on mobile

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: prompted for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a81c3d45dc832397990a1bc20669ac