### PR TITLE
fix: handle invalid login without session expired message

### DIFF
--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -87,7 +87,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const interceptor = api.interceptors.response.use(
       response => response,
       error => {
-        if (error.response?.status === 401) {
+        const originalRequest = error.config;
+        if (
+          error.response?.status === 401 &&
+          !originalRequest?.url?.includes('/auth/login')
+        ) {
           handleTokenExpired();
         }
         return Promise.reject(error);


### PR DESCRIPTION
## Summary
- avoid showing session-expired toast on failed login attempts by excluding `/auth/login` from 401 interceptor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b51230183c83238d92ea5893fe0b0b