### PR TITLE
feat: add password reset flow

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "nodemailer": "^6.9.8",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.0",
@@ -6741,6 +6742,15 @@
       "version": "2.0.19",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "@nestjs/swagger": "^7.3.1",
     "@prisma/client": "^6.13.0",
     "bcrypt": "^5.1.1",
+    "nodemailer": "^6.9.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "passport": "^0.7.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -19,6 +20,11 @@ export class AuthController {
   @Post('login')
   login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
+  }
+
+  @Post('forgot-password')
+  forgotPassword(@Body() forgotPasswordDto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(forgotPasswordDto.email);
   }
 
   @Post('refresh')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 
-import { Injectable, UnauthorizedException, ConflictException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ConflictException, NotFoundException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
@@ -7,6 +7,7 @@ import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import * as nodemailer from 'nodemailer';
 
 @Injectable()
 export class AuthService {
@@ -60,5 +61,41 @@ export class AuthService {
       accessToken: this.jwtService.sign(payload, { secret: this.configService.get('JWT_SECRET'), expiresIn: '59m' }),
       refreshToken: this.jwtService.sign(payload, { secret: this.configService.get('JWT_REFRESH_SECRET'), expiresIn: '7d' }),
     };
+  }
+
+  async forgotPassword(email: string) {
+    const user = await this.usersService.findOneByEmail(email);
+    if (!user) {
+      throw new NotFoundException('Email not found');
+    }
+
+    const token = this.jwtService.sign(
+      { sub: user.id },
+      {
+        secret: this.configService.get('JWT_SECRET'),
+        expiresIn: '1h',
+      },
+    );
+
+    const resetLink = `${this.configService.get('FRONTEND_URL')}/reset-password?token=${token}`;
+
+    const transporter = nodemailer.createTransport({
+      host: this.configService.get('SMTP_HOST'),
+      port: this.configService.get('SMTP_PORT'),
+      secure: false,
+      auth: {
+        user: this.configService.get('SMTP_USER'),
+        pass: this.configService.get('SMTP_PASS'),
+      },
+    });
+
+    await transporter.sendMail({
+      from: this.configService.get('SMTP_FROM') || this.configService.get('SMTP_USER'),
+      to: email,
+      subject: 'Password Reset',
+      text: `Reset your password using the following link: ${resetLink}`,
+    });
+
+    return { message: 'Password reset email sent' };
   }
 }

--- a/backend/src/auth/dto/forgot-password.dto.ts
+++ b/backend/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useForm, SubmitHandler } from "react-hook-form";
+import api from "@/lib/api";
+import { toast } from "sonner";
+import Link from "next/link";
+import { Prompt } from "next/font/google";
+
+interface ForgotPasswordForm {
+  email: string;
+}
+
+const prompt = Prompt({
+  weight: ["400", "500", "700"],
+  subsets: ["thai", "latin"],
+});
+
+export default function ForgotPasswordPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordForm>();
+
+  const onSubmit: SubmitHandler<ForgotPasswordForm> = async (data) => {
+    try {
+      await api.post("/auth/forgot-password", data);
+      toast.success("เราได้ส่งลิงก์รีเซ็ตรหัสผ่านไปยังอีเมลของคุณแล้ว");
+    } catch (error: any) {
+      toast.error(
+        error.response?.data?.message || "ไม่สามารถส่งลิงก์รีเซ็ตรหัสผ่านได้"
+      );
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-400">
+      <div className="bg-white p-8 rounded-2xl shadow-2xl w-full max-w-md">
+        <h1
+          className={`${prompt.className} text-center text-2xl font-bold mb-6`}
+        >
+          ลืมรหัสผ่าน
+        </h1>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <input
+              type="email"
+              placeholder="EMAIL"
+              {...register("email", { required: "Email is required" })}
+              className="w-full px-4 py-2 bg-white border border-gray-300 rounded-xl focus:ring-2 focus:ring-gray-400 focus:border-transparent transition placeholder:text-sm"
+            />
+            {errors.email && (
+              <p className="text-red-500 text-sm mt-1">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full py-2 text-white bg-gray-500 rounded-xl hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 transition disabled:bg-gray-400"
+          >
+            {isSubmitting ? "กำลังส่ง..." : "ส่งลิงก์รีเซ็ต"}
+          </button>
+        </form>
+        <p className="text-center mt-4">
+          <Link
+            href="/login"
+            className={`${prompt.className} text-gray-600 hover:text-gray-900`}
+          >
+            กลับสู่หน้าล็อกอิน
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -154,7 +154,7 @@ export default function LoginPage() {
                 </label>
               </div>
               <Link
-                href="#"
+                href="/forgot-password"
                 className={`${prompt.className} text-gray-600 hover:text-gray-900`}
               >
                 ลืมรหัสผ่าน


### PR DESCRIPTION
## Summary
- add forgot password page and link from login
- implement backend endpoint to send reset link via email
- include nodemailer dependency

## Testing
- `npm test -- --passWithNoTests`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b51c79c678832382e89cbb67f81ebb