### PR TITLE
feat: add report submenu

### DIFF
--- a/frontend/app/dashboard/_components/Sidebar.tsx
+++ b/frontend/app/dashboard/_components/Sidebar.tsx
@@ -22,7 +22,17 @@ import Image from "next/image";
 
 // --- Data structure for navigation items ---
 const navItems = [
-  { href: "/dashboard", label: "รายงาน", icon: BarChart2 },
+  {
+    href: "/dashboard",
+    label: "รายงาน",
+    icon: BarChart2,
+    children: [
+      { href: "/dashboard", label: "รายงานภาพรวม" },
+      { href: "/dashboard/sales-report", label: "รายงานการขาย" },
+      { href: "/dashboard/marketing-report", label: "รายงานการตลาด" },
+      { href: "/dashboard/activity-report", label: "รายงานกิจกรรม" },
+    ],
+  },
   { href: "/dashboard/activities", label: "กิจกรรม", icon: Activity },
   { href: "/dashboard/calendar", label: "ปฏิทิน", icon: Calendar },
   { href: "/dashboard/map", label: "แผนที่", icon: Map },
@@ -120,13 +130,16 @@ const NavItem = ({
             {item.children.map((child: any) => (
               <Link key={child.href} href={child.href} onClick={onLinkClick}>
                 <div
-                  className={`block p-2 text-sm rounded-md transition-colors ${
+                  className={`flex items-center justify-between p-2 text-sm rounded-md transition-colors ${
                     pathname === child.href
                       ? "text-white font-bold"
                       : "text-red-200 hover:text-white"
                   }`}
                 >
-                  {child.label}
+                  <span>{child.label}</span>
+                  {pathname === child.href && (
+                    <span className="w-2 h-2 bg-red-500 rounded-full"></span>
+                  )}
                 </div>
               </Link>
             ))}
@@ -177,9 +190,14 @@ export default function Sidebar({
 
   // This effect ensures the correct submenu is open based on the current URL
   useEffect(() => {
-    // Find if the current path belongs to a parent menu with children
+    // Find if the current path belongs to a parent menu by checking its children
     const parentMenu = navItems.find(
-      (item) => item.children && pathname.startsWith(item.href)
+      (item) =>
+        item.children &&
+        item.children.some(
+          (child: any) =>
+            pathname === child.href || pathname.startsWith(child.href + "/")
+        )
     );
 
     if (parentMenu) {

--- a/frontend/app/dashboard/activity-report/page.tsx
+++ b/frontend/app/dashboard/activity-report/page.tsx
@@ -1,0 +1,8 @@
+export default function ActivityReportPage() {
+  return (
+    <div>
+      <h1>รายงานกิจกรรม</h1>
+      <p>เนื้อหาของรายงานกิจกรรมจะแสดงที่นี่...</p>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/marketing-report/page.tsx
+++ b/frontend/app/dashboard/marketing-report/page.tsx
@@ -1,0 +1,8 @@
+export default function MarketingReportPage() {
+  return (
+    <div>
+      <h1>รายงานการตลาด</h1>
+      <p>เนื้อหาของรายงานการตลาดจะแสดงที่นี่...</p>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/sales-report/page.tsx
+++ b/frontend/app/dashboard/sales-report/page.tsx
@@ -1,0 +1,8 @@
+export default function SalesReportPage() {
+  return (
+    <div>
+      <h1>รายงานการขาย</h1>
+      <p>เนื้อหาของรายงานการขายจะแสดงที่นี่...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add report submenu with links for overview, sales, marketing and activity reports
- show red indicator for active report item and persist open state for report pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt prevents completion)


------
https://chatgpt.com/codex/tasks/task_e_68b55566c6fc8323950cd6992c20e87d