### PR TITLE
feat: add forgot password flow

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "nodemailer": "^7.0.6",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.0",
@@ -6741,6 +6742,15 @@
       "version": "2.0.19",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,27 +5,26 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
-"scripts": {
-  "build": "nest build",
-  "build:seed": "tsc --project tsconfig.seed.json",
-  "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-  "start": "nest start",
-  "start:dev": "ts-node-dev --respawn --transpile-only --exit-child --poll=3000 src/main.ts",
-  "start:debug": "nest start --debug --watch",
-  "start:prod": "node dist/main",
-  "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-  "test": "jest",
-  "test:watch": "jest --watch",
-  "test:cov": "jest --coverage",
-  "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-  "test:e2e": "jest --config ./test/jest-e2e.json",
-  "prisma:dev:deploy": "prisma migrate deploy",
-  "db:push": "prisma db push",
-  "prisma:studio": "prisma studio"
-},
-
+  "scripts": {
+    "build": "nest build",
+    "build:seed": "tsc --project tsconfig.seed.json",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "ts-node-dev --respawn --transpile-only --exit-child --poll=3000 src/main.ts",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prisma:dev:deploy": "prisma migrate deploy",
+    "db:push": "prisma db push",
+    "prisma:studio": "prisma studio"
+  },
   "prisma": {
-     "seed": "node prisma/seed.mjs"
+    "seed": "node prisma/seed.mjs"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -39,6 +38,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "nodemailer": "^7.0.6",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -24,6 +25,11 @@ export class AuthController {
   @Post('refresh')
   refresh(@Body() refreshTokenDto: RefreshTokenDto) {
     return this.authService.refreshToken(refreshTokenDto.refreshToken);
+  }
+
+  @Post('forgot-password')
+  forgotPassword(@Body() forgotPasswordDto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(forgotPasswordDto.email);
   }
 
   @ApiBearerAuth()

--- a/backend/src/auth/dto/forgot-password.dto.ts
+++ b/backend/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -5,8 +5,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { useAuth } from "@/context/AuthContext";
 import api from "@/lib/api";
 import { toast } from "sonner";
-import Link from "next/link";
-import { Eye, EyeOff, ArrowRight } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
 import Image from "next/image";
 import { Prompt } from "next/font/google";
 
@@ -40,6 +39,7 @@ export default function LoginPage() {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
+    watch,
   } = useForm<LoginFormInputs>();
   const { login } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
@@ -53,6 +53,20 @@ export default function LoginPage() {
         error.response?.data?.message ||
           "Login failed. Please check your credentials."
       );
+    }
+  };
+
+  const handleForgotPassword = async () => {
+    const email = watch("email");
+    if (!email) {
+      toast.error("Please enter your email first.");
+      return;
+    }
+    try {
+      await api.post("/auth/forgot-password", { email });
+      toast.success("Password reset email sent");
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || "Email not found");
     }
   };
 
@@ -153,12 +167,13 @@ export default function LoginPage() {
                   บันทึกรหัส
                 </label>
               </div>
-              <Link
-                href="#"
+              <button
+                type="button"
+                onClick={handleForgotPassword}
                 className={`${prompt.className} text-gray-600 hover:text-gray-900`}
               >
                 ลืมรหัสผ่าน
-              </Link>
+              </button>
             </div>
             <div className="flex justify-center">
               <button


### PR DESCRIPTION
## Summary
- add DTO, controller route, and service to handle password reset email
- enable reset via login page with existing email check

## Testing
- `npm test` (backend) *(fails: No tests found)*
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b670235f3c83238e85860e48f89e9f