### PR TITLE
Add role-based redirect and permission testing buttons

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import PermissionButtons from "@/components/PermissionButtons";
+
+export default function AdminPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Admin Page</h1>
+      <PermissionButtons />
+    </div>
+  );
+}

--- a/frontend/app/admin/users_old/page.tsx
+++ b/frontend/app/admin/users_old/page.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { PlusCircle, Trash2, Edit, X, AlertTriangle, Search, ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import PermissionButtons from '@/components/PermissionButtons';
 
 // --- Type Definitions ---
 interface Role {
@@ -250,6 +251,8 @@ export default function AdminUsersPage() {
         <Link href="/admin/roles" className="text-blue-600 hover:underline">Roles</Link>
         <Link href="/admin/permissions" className="text-blue-600 hover:underline">Permissions</Link>
       </nav>
+
+      <PermissionButtons />
 
       <div className="bg-white p-6 md:p-8 rounded-2xl shadow-lg w-full min-h-full">
         <div className="flex flex-col md:flex-row justify-between items-center mb-8">

--- a/frontend/app/dashboard/_components/Sidebar.tsx
+++ b/frontend/app/dashboard/_components/Sidebar.tsx
@@ -72,6 +72,13 @@ const roleMenuRestrictions: Record<string, string[]> = {
   SALES_EMPLOYEE: ["/dashboard", "/dashboard/marketing"],
 };
 
+// Restrict menu visibility based on user type
+const typeMenuRestrictions: Record<string, string[]> = {
+  User: ["/dashboard/employee", "/dashboard/roles"],
+  GM: ["/dashboard/roles"],
+  Admin: [],
+};
+
 const Logo = () => (
   <div className="bg-red-650 p-4 flex items-center justify-center mb-6 mr-5 mt-4">
     <div className="relative w-36 h-36 rounded-lg overflow-hidden p-2">
@@ -189,14 +196,19 @@ export default function Sidebar({
 
   const filteredNavItems = navItems.filter((item) => {
     const roleName = user?.role.name;
-    
+    const userType = user?.type as keyof typeof typeMenuRestrictions;
+
     if (item.href.startsWith("/dashboard/roles")) {
-      return roleName === "ADMIN" || roleName === "CEO";
+      return userType === "Admin";
     }
 
-    const restricted =
+    const roleRestricted =
       roleMenuRestrictions[roleName as keyof typeof roleMenuRestrictions] || [];
-    return !restricted.includes(item.href);
+    const typeRestricted = typeMenuRestrictions[userType] || [];
+    return (
+      !roleRestricted.includes(item.href) &&
+      !typeRestricted.includes(item.href)
+    );
   });
 
   // This effect ensures the correct submenu is open based on the current URL

--- a/frontend/app/dashboard/employee/create/page.tsx
+++ b/frontend/app/dashboard/employee/create/page.tsx
@@ -44,6 +44,7 @@ type CreateEmployeeFormInputs = {
   phone: string;
   email: string;
   password: string;
+  userType: string;
   roleId: string;
   birthDate: string;
   address: string;
@@ -70,6 +71,7 @@ export default function CreateEmployeePage() {
     formState: { isSubmitting, errors },
   } = useForm<CreateEmployeeFormInputs>({
     shouldFocusError: true,
+    defaultValues: { userType: "User" },
   });
   const [roles, setRoles] = useState<Role[]>([]);
   const [birthDate, setBirthDate] = useState<Date | undefined>();
@@ -93,8 +95,9 @@ export default function CreateEmployeePage() {
   }, []);
 
   const onSubmit: SubmitHandler<CreateEmployeeFormInputs> = async (data) => {
+    const { userType, ...rest } = data;
     const payload = {
-      ...data,
+      ...rest,
       email: data.email.trim(),
       age: data.age ? Number(data.age) : undefined,
       birthDate: data.birthDate
@@ -105,6 +108,7 @@ export default function CreateEmployeePage() {
         : undefined,
       endDate: data.endDate ? new Date(data.endDate).toISOString() : undefined,
       roleId: Number(data.roleId),
+      type: userType,
     };
     try {
       await api.post("/employees", payload);
@@ -618,6 +622,39 @@ export default function CreateEmployeePage() {
                   {errors.password.message as string}
                 </p>
               )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                ประเภทผู้ใช้ *
+              </label>
+              <Select
+                defaultValue="User"
+                onValueChange={(value) =>
+                  setValue("userType", value, { shouldValidate: true })
+                }
+              >
+                <SelectTrigger
+                  className={cn("w-full", errors.userType && "border-red-500")}
+                >
+                  <SelectValue placeholder="กรุณาเลือก" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Admin">Admin</SelectItem>
+                  <SelectItem value="GM">GM</SelectItem>
+                  <SelectItem value="User">User</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.userType && (
+                <p className="flex items-center mt-1 text-xs text-red-500">
+                  <AlertTriangle size={14} className="mr-1" />
+                  {errors.userType.message as string}
+                </p>
+              )}
+              <input
+                type="hidden"
+                {...register("userType", { required: "กรุณาเลือกประเภทผู้ใช้" })}
+              />
             </div>
 
             <div>

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import Sidebar from "./_components/Sidebar";
 import Header from "./_components/Header";
 import { useAuth } from "@/context/AuthContext";
 import { usePathname } from "next/navigation";
+import PermissionButtons from "@/components/PermissionButtons";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   const { user, isLoading } = useAuth();
@@ -42,6 +43,7 @@ return (
 
       {/* สกอร์ลตัวเดียวของทั้งหน้า */}
       <main className="flex-1 min-h-0 overflow-x-hidden overflow-y-auto bg-gray-100 rounded-tl-3xl p-4 md:p-8">
+        <PermissionButtons />
         {children}
       </main>
     </div>

--- a/frontend/components/PermissionButtons.tsx
+++ b/frontend/components/PermissionButtons.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/context/AuthContext";
+import { Plus, Pencil, Trash } from "lucide-react";
+
+export default function PermissionButtons() {
+  const { user } = useAuth();
+
+  return (
+    <div className="flex gap-2 mb-4">
+      <Button size="sm">
+        <Plus className="h-4 w-4 mr-2" /> สร้าง
+      </Button>
+      {user?.type !== "User" && (
+        <Button size="sm" variant="secondary">
+          <Pencil className="h-4 w-4 mr-2" /> แก้ไข
+        </Button>
+      )}
+      {user?.type === "Admin" && (
+        <Button size="sm" variant="destructive">
+          <Trash className="h-4 w-4 mr-2" /> ลบ
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -19,6 +19,7 @@ interface User {
   email: string;
   name: string;
   role: { name: string; permissions: any[] };
+  type?: string;
 }
 
 interface AuthContextType {
@@ -116,7 +117,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     api.get('/auth/profile').then(response => {
       setUser(response.data);
       toast.success(`เข้าสู่ระบบสำเร็จ`);
-      router.push('/dashboard');
+      const role = response.data.type || response.data.role?.name;
+      if (role === 'Admin') {
+        router.push('/admin');
+      } else {
+        router.push('/dashboard');
+      }
     });
   };
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -8,9 +8,21 @@ export function middleware(request: NextRequest) {
   const authRoutes = ['/login', '/register'];
   const protectedRoutes = ['/dashboard', '/admin'];
 
-  // If trying to access auth page while logged in, redirect to dashboard
+  const decodeToken = (token: string) => {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      return payload;
+    } catch {
+      return null;
+    }
+  };
+
+  // If trying to access auth page while logged in, redirect to proper page
   if (accessToken && authRoutes.includes(pathname)) {
-    return NextResponse.redirect(new URL('/dashboard', request.url));
+    const payload: any = decodeToken(accessToken);
+    const role = payload?.type || payload?.role;
+    const target = role === 'Admin' ? '/admin' : '/dashboard';
+    return NextResponse.redirect(new URL(target, request.url));
   }
 
   // If trying to access protected page while not logged in, redirect to login


### PR DESCRIPTION
## Summary
- Redirect users to role-specific dashboards after login and from auth routes
- Restrict sidebar menus by user type and add permission testing buttons
- Provide user type selection (Admin/GM/User) when creating employees

## Testing
- `npm test` *(fails: Missing script "test" [npm error])* 
- `npm run lint` *(cannot complete: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b691b8f00c83239f284588ffca4b4d