### PR TITLE
Add user type with role-based redirects and UI controls

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   status         String?  @default("Active")
   company        String?
   responsibleArea String?
+  type           String  @default("User")
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -33,7 +33,7 @@ export class AuthService {
     const isMatch = await bcrypt.compare(loginDto.password, user.password);
     if (!isMatch) throw new UnauthorizedException('Invalid credentials');
     if (user.status && user.status.toLowerCase() === 'inactive') throw new UnauthorizedException('User inactive');
-    return this.generateTokens(user.id, user.email, user.role.name);
+    return this.generateTokens(user.id, user.email, user.role.name, user.type);
   }
 
   async refreshToken(refreshToken: string) {
@@ -41,7 +41,7 @@ export class AuthService {
       const payload = this.jwtService.verify(refreshToken, { secret: this.configService.get('JWT_REFRESH_SECRET') });
       const user = await this.usersService.findOne(payload.sub);
       if (!user) throw new UnauthorizedException();
-      return this.generateTokens(user.id, user.email, user.role.name);
+      return this.generateTokens(user.id, user.email, user.role.name, user.type);
     } catch (e) {
       throw new UnauthorizedException('Invalid refresh token');
     }
@@ -65,8 +65,8 @@ export class AuthService {
     return { message: 'ส่งลิงก์รีเซ็ตรหัสผ่านไปที่อีเมลแล้ว' };
   }
 
-  private async generateTokens(userId: number, email: string, role: string) {
-    const payload = { email, sub: userId, role };
+  private async generateTokens(userId: number, email: string, role: string, type: string) {
+    const payload = { email, sub: userId, role, type };
     return {
       accessToken: this.jwtService.sign(payload, { secret: this.configService.get('JWT_SECRET'), expiresIn: '59m' }),
       refreshToken: this.jwtService.sign(payload, { secret: this.configService.get('JWT_REFRESH_SECRET'), expiresIn: '7d' }),

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -12,7 +12,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       secretOrKey: configService.get('JWT_SECRET'),
     });
   }
-  async validate(payload: { sub: number; email: string; role: string }) {
+  async validate(payload: { sub: number; email: string; role: string; type: string }) {
     const user = await this.usersService.findOne(payload.sub);
     if (!user) throw new UnauthorizedException();
     return { userId: payload.sub, email: payload.email, role: user.role };

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsNumber, IsString, MinLength, IsOptional } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsNumber, IsString, MinLength, IsOptional, IsIn } from 'class-validator';
 export class CreateUserDto {
   @IsString()
   @IsNotEmpty()
@@ -26,4 +26,8 @@ export class CreateUserDto {
   @IsOptional()
   @IsString()
   responsibleArea?: string;
+
+  @IsOptional()
+  @IsIn(['Admin', 'GM', 'User'])
+  type?: string;
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -21,7 +21,7 @@ export class UsersService {
 
   findAll() {
     return this.prisma.user.findMany({
-      select: { id: true, email: true, name: true, role: true, createdAt: true },
+      select: { id: true, email: true, name: true, role: true, type: true, createdAt: true },
     });
   }
 
@@ -77,7 +77,7 @@ export class UsersService {
     return this.prisma.user.update({
       where: { id },
       data,
-      select: { id: true, email: true, name: true, role: true },
+      select: { id: true, email: true, name: true, role: true, type: true },
     });
   }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,21 +8,23 @@ import { useAuth } from '@/context/AuthContext';
 // Its only job is to redirect the user to the correct page based on their auth state.
 
 export default function HomePage() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     // We don't want to redirect until we are sure about the auth state.
     if (!isLoading) {
       if (isAuthenticated) {
-        // If the user is logged in, send them to the dashboard.
-        router.replace('/dashboard');
+        if (user?.type === 'Admin') {
+          router.replace('/admin');
+        } else {
+          router.replace('/dashboard');
+        }
       } else {
-        // If the user is not logged in, send them to the login page.
         router.replace('/login');
       }
     }
-  }, [isAuthenticated, isLoading, router]);
+  }, [isAuthenticated, isLoading, router, user]);
 
   // Display a simple loading screen while checking the auth state
   // to prevent a flash of unstyled content or incorrect redirects.

--- a/frontend/components/PermissionButtons.tsx
+++ b/frontend/components/PermissionButtons.tsx
@@ -12,7 +12,7 @@ export default function PermissionButtons() {
       <Button size="sm">
         <Plus className="h-4 w-4 mr-2" /> สร้าง
       </Button>
-      {user?.type !== "User" && (
+      {(user?.type === "GM" || user?.type === "Admin") && (
         <Button size="sm" variant="secondary">
           <Pencil className="h-4 w-4 mr-2" /> แก้ไข
         </Button>

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -19,7 +19,7 @@ interface User {
   email: string;
   name: string;
   role: { name: string; permissions: any[] };
-  type?: string;
+  type: 'Admin' | 'GM' | 'User';
 }
 
 interface AuthContextType {
@@ -71,7 +71,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           // Set the auth header for the initial request
           api.defaults.headers.Authorization = `Bearer ${accessToken}`;
           const profile = await api.get('/auth/profile');
-          setUser(profile.data);
+          const userData = { ...profile.data, type: profile.data.type || 'User' };
+          setUser(userData);
           startTokenTimer(accessToken);
         } catch (error) {
           console.error('Failed to fetch profile, session might be expired.', error);
@@ -115,10 +116,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     // Fetch user profile to update the state
     api.get('/auth/profile').then(response => {
-      setUser(response.data);
+      const userData = { ...response.data, type: response.data.type || 'User' };
+      setUser(userData);
       toast.success(`เข้าสู่ระบบสำเร็จ`);
-      const role = response.data.type || response.data.role?.name;
-      if (role === 'Admin') {
+      if (userData.type === 'Admin') {
         router.push('/admin');
       } else {
         router.push('/dashboard');


### PR DESCRIPTION
## Summary
- add `type` field with default `User` for Admin/GM/User handling
- include type in auth tokens and redirect users to admin or dashboard pages
- show add/edit/delete buttons according to user type

## Testing
- `npm test` (backend) *(fails: No tests found)*
- `npm run build` (frontend)
- `npm run lint` (frontend) *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6966686748323a79882ccca50538a