### PR TITLE
feat: add activity management with role-based access

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,6 +42,20 @@ model User {
 
   role   Role @relation(fields: [roleId], references: [id])
   roleId Int
+
+  activities     Activity[]
+}
+
+model Activity {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String?
+  department  String?
+  createdById Int
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  createdBy   User     @relation(fields: [createdById], references: [id])
 }
 
 model Role {

--- a/backend/src/activities/activities.controller.ts
+++ b/backend/src/activities/activities.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Request, ParseIntPipe } from '@nestjs/common';
+import { ActivitiesService } from './activities.service';
+import { CreateActivityDto } from './dto/create-activity.dto';
+import { UpdateActivityDto } from './dto/update-activity.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('activities')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('activities')
+export class ActivitiesController {
+  constructor(private readonly activitiesService: ActivitiesService) {}
+
+  @Post()
+  @Roles('ADMIN', 'MANAGER', 'USER')
+  create(@Request() req, @Body() createActivityDto: CreateActivityDto) {
+    return this.activitiesService.create(createActivityDto, req.user);
+  }
+
+  @Get()
+  @Roles('ADMIN', 'MANAGER', 'USER')
+  findAll(@Request() req) {
+    return this.activitiesService.findAll(req.user);
+  }
+
+  @Get(':id')
+  @Roles('ADMIN', 'MANAGER', 'USER')
+  findOne(@Request() req, @Param('id', ParseIntPipe) id: number) {
+    return this.activitiesService.findOne(id, req.user);
+  }
+
+  @Patch(':id')
+  @Roles('ADMIN', 'MANAGER', 'USER')
+  update(@Request() req, @Param('id', ParseIntPipe) id: number, @Body() updateActivityDto: UpdateActivityDto) {
+    return this.activitiesService.update(id, updateActivityDto, req.user);
+  }
+
+  @Delete(':id')
+  @Roles('ADMIN', 'MANAGER', 'USER')
+  remove(@Request() req, @Param('id', ParseIntPipe) id: number) {
+    return this.activitiesService.remove(id, req.user);
+  }
+}

--- a/backend/src/activities/activities.module.ts
+++ b/backend/src/activities/activities.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ActivitiesService } from './activities.service';
+import { ActivitiesController } from './activities.controller';
+
+@Module({
+  controllers: [ActivitiesController],
+  providers: [ActivitiesService],
+})
+export class ActivitiesModule {}

--- a/backend/src/activities/activities.service.ts
+++ b/backend/src/activities/activities.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateActivityDto } from './dto/create-activity.dto';
+import { UpdateActivityDto } from './dto/update-activity.dto';
+
+@Injectable()
+export class ActivitiesService {
+  constructor(private prisma: PrismaService) {}
+
+  create(createActivityDto: CreateActivityDto, user: any) {
+    return this.prisma.activity.create({
+      data: {
+        ...createActivityDto,
+        createdById: user.userId,
+        department: user.department || null,
+      },
+    });
+  }
+
+  findAll(user: any) {
+    if (user.role?.name === 'ADMIN') {
+      return this.prisma.activity.findMany();
+    }
+    if (user.role?.name === 'MANAGER') {
+      return this.prisma.activity.findMany({
+        where: { department: user.department || undefined },
+      });
+    }
+    return this.prisma.activity.findMany({ where: { createdById: user.userId } });
+  }
+
+  async findOne(id: number, user: any) {
+    const activity = await this.prisma.activity.findUnique({ where: { id } });
+    if (!activity) throw new NotFoundException('Activity not found');
+    if (this.canAccess(activity, user)) return activity;
+    throw new ForbiddenException('Access denied');
+  }
+
+  async update(id: number, updateActivityDto: UpdateActivityDto, user: any) {
+    const activity = await this.prisma.activity.findUnique({ where: { id } });
+    if (!activity) throw new NotFoundException('Activity not found');
+    if (!this.canAccess(activity, user)) throw new ForbiddenException('Access denied');
+    return this.prisma.activity.update({ where: { id }, data: updateActivityDto });
+  }
+
+  async remove(id: number, user: any) {
+    const activity = await this.prisma.activity.findUnique({ where: { id } });
+    if (!activity) throw new NotFoundException('Activity not found');
+    if (!this.canAccess(activity, user)) throw new ForbiddenException('Access denied');
+    return this.prisma.activity.delete({ where: { id } });
+  }
+
+  private canAccess(activity: any, user: any) {
+    if (user.role?.name === 'ADMIN') return true;
+    if (user.role?.name === 'MANAGER' && activity.department === user.department) return true;
+    return activity.createdById === user.userId;
+  }
+}

--- a/backend/src/activities/dto/create-activity.dto.ts
+++ b/backend/src/activities/dto/create-activity.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateActivityDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/backend/src/activities/dto/update-activity.dto.ts
+++ b/backend/src/activities/dto/update-activity.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateActivityDto } from './create-activity.dto';
+
+export class UpdateActivityDto extends PartialType(CreateActivityDto) {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { RolesModule } from './roles/roles.module';
 import { PermissionsModule } from './permissions/permissions.module';
 import { EmployeesModule } from './employees/employees.module';
 import { ThaiAddressModule } from './thai-address/thai-address.module';
+import { ActivitiesModule } from './activities/activities.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { ThaiAddressModule } from './thai-address/thai-address.module';
     PermissionsModule,
     EmployeesModule,
     ThaiAddressModule,
+    ActivitiesModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -15,6 +15,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   async validate(payload: { sub: number; email: string; role: string; type: string }) {
     const user = await this.usersService.findOne(payload.sub);
     if (!user) throw new UnauthorizedException();
-    return { userId: payload.sub, email: payload.email, role: user.role };
+    return { userId: payload.sub, email: payload.email, role: user.role, department: user.department };
   }
 }

--- a/frontend/app/dashboard/activities/page.tsx
+++ b/frontend/app/dashboard/activities/page.tsx
@@ -1,12 +1,115 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+import { useAuth } from '@/context/AuthContext';
+
+interface Activity {
+  id: number;
+  title: string;
+  description?: string;
+  createdById: number;
+  department?: string | null;
+}
+
 export default function ActivitiesPage() {
+  const { user } = useAuth();
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [form, setForm] = useState({ title: '', description: '' });
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const fetchActivities = async () => {
+    const res = await api.get('/activities');
+    setActivities(res.data);
+  };
+
+  useEffect(() => {
+    fetchActivities();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId) {
+      await api.patch(`/activities/${editingId}`, form);
+    } else {
+      await api.post('/activities', form);
+    }
+    setForm({ title: '', description: '' });
+    setEditingId(null);
+    fetchActivities();
+  };
+
+  const handleEdit = (activity: Activity) => {
+    setForm({ title: activity.title, description: activity.description || '' });
+    setEditingId(activity.id);
+  };
+
+  const handleDelete = async (id: number) => {
+    await api.delete(`/activities/${id}`);
+    fetchActivities();
+  };
+
+  const canModify = (activity: Activity) => {
+    if (!user) return false;
+    if (user.role?.name === 'ADMIN') return true;
+    if (user.role?.name === 'MANAGER' && user.department && activity.department === user.department)
+      return true;
+    return activity.createdById === user.id;
+  };
+
   return (
     <div className="bg-white w-full min-h-full rounded-2xl shadow-lg p-6 md:p-8">
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">
-        หน้ากิจกรรม (Activities)
-      </h1>
-      <p>เนื้อหาของหน้ากิจกรรมจะแสดงที่นี่...</p>
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">หน้ากิจกรรม (Activities)</h1>
+
+      <form onSubmit={handleSubmit} className="mb-4 space-y-2">
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="หัวข้อ"
+          className="border p-2 w-full"
+          required
+        />
+        <textarea
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          placeholder="รายละเอียด"
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+          {editingId ? 'แก้ไข' : 'เพิ่ม'} กิจกรรม
+        </button>
+        {editingId && (
+          <button
+            type="button"
+            onClick={() => {
+              setEditingId(null);
+              setForm({ title: '', description: '' });
+            }}
+            className="ml-2 px-4 py-2 rounded border"
+          >
+            ยกเลิก
+          </button>
+        )}
+      </form>
+
+      <ul className="space-y-4">
+        {activities.map((act) => (
+          <li key={act.id} className="border p-4 rounded">
+            <h2 className="font-bold">{act.title}</h2>
+            <p>{act.description}</p>
+            {canModify(act) && (
+              <div className="mt-2 space-x-2">
+                <button onClick={() => handleEdit(act)} className="text-blue-500">
+                  แก้ไข
+                </button>
+                <button onClick={() => handleDelete(act.id)} className="text-red-500">
+                  ลบ
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -20,6 +20,7 @@ interface User {
   name: string;
   role: { name: string; permissions: any[] };
   type: 'Admin' | 'GM' | 'User';
+  department?: string | null;
 }
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- add Activity prisma model and Nest module with CRUD endpoints and access control for creators, department managers, and admins
- include user department in JWT context and auth context
- implement dashboard Activities page with forms to create, update, and delete activities based on permissions

## Testing
- `npm --prefix backend test -- --passWithNoTests`
- `npm --prefix frontend test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7fdb8e6a88323bb919e9b5285c154